### PR TITLE
Clang format the custom typings and minor custom typings refactor

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,4 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 BinPackArguments: false
 BinPackParameters: false
+

--- a/.clang-format
+++ b/.clang-format
@@ -8,4 +8,3 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 BinPackArguments: false
 BinPackParameters: false
-

--- a/custom_typings/bottleneck.d.ts
+++ b/custom_typings/bottleneck.d.ts
@@ -1,5 +1,4 @@
-declare module "bottleneck" {
-
+declare module 'bottleneck' {
   interface PromiseProducer<T> {
     (...args: any[]): Promise<T>;
   }
@@ -9,10 +8,9 @@ declare module "bottleneck" {
     schedule<T>(promise: PromiseProducer<T>): Promise<T>;
     schedule<T>(promise: PromiseProducer<T>, A1: any): Promise<T>;
     schedule<T>(promise: PromiseProducer<T>, A1: any, A2: any): Promise<T>;
-    schedule<T>(promise: PromiseProducer<T>, A1: any, A2: any, A3: any): Promise<T>;
+    schedule<T>(promise: PromiseProducer<T>, A1: any, A2: any, A3: any):
+        Promise<T>;
   }
-  namespace Bottleneck {
-
-  }
+  namespace Bottleneck {}
   export = Bottleneck;
 }

--- a/custom_typings/command-line-args.d.ts
+++ b/custom_typings/command-line-args.d.ts
@@ -1,25 +1,27 @@
-declare module "command-line-args" {
-  interface ArgDescriptor {
-    name: string;
-    // type: Object;
-    alias?: string;
-    description: string;
-    defaultValue?: any;
-    type: (val: string) => any;
-    multiple?: boolean;
-  }
-  interface UsageOpts {
-    title: string;
-    header?: string;
-    description?: string;
-  }
-  interface CLI {
-    parse(): any;
-    getUsage(opts: UsageOpts): string;
-  }
+declare module 'command-line-args' {
+  function commandLineArgs(args: commandLineArgs.ArgDescriptor[]):
+      commandLineArgs.CLI;
 
-  function commandLineArgs(args: ArgDescriptor[]): CLI;
-  namespace commandLineArgs {}
+  namespace commandLineArgs {
+    interface ArgDescriptor {
+      name: string;
+      // type: Object;
+      alias?: string;
+      description: string;
+      defaultValue?: any;
+      type: (val: string) => any;
+      multiple?: boolean;
+    }
+    interface UsageOpts {
+      title: string;
+      header?: string;
+      description?: string;
+    }
+    interface CLI {
+      parse(): any;
+      getUsage(opts: UsageOpts): string;
+    }
+  }
 
   export = commandLineArgs;
 }

--- a/custom_typings/github.d.ts
+++ b/custom_typings/github.d.ts
@@ -1,51 +1,57 @@
-declare module "github" {
-  interface Options {
-    version: string;
-    protocol: string;
-  }
-  interface CreatePullRequestOpts {
-    user: string;
-    repo: string;
-    title: string;
-    head: string;
-    base: string;
-    body?: string;
-  }
-  interface IssuesEditOpts {
-    headers?: Object;
-    user: string;
-    repo: string;
-    number: number;
-    title?: string;
-    body?: string;
-    assignee?: string;
-    milestone?: number;
-    labels?: string[];
-    state?: string;
-  }
-  interface GetFromOrgOpts {
-    org: string;
-    per_page?: number;
-    page?: number;
-  }
+declare module 'github' {
   class GitHubApi {
-    constructor(options: Options);
-    repos: {
-      getFromOrg(msg: GetFromOrgOpts, cb: NodeCallback<GitHubApi.Repo[]>): void;
+    constructor(options: GitHubApi.Options);
+    repos: ({
+      getFromOrg(
+          msg: GitHubApi.GetFromOrgOpts,
+          cb: NodeCallback<GitHubApi.Repo[]>): void;
       get(msg: {user: string, repo: string},
           cb: NodeCallback<GitHubApi.Repo>): void;
-    };
-    pullRequests: {
+    });
+    pullRequests: ({
       create(
-          msg: CreatePullRequestOpts, cb: NodeCallback<GitHubApi.Issue>): void;
-    };
-    issues: {
-      edit(msg: IssuesEditOpts, cb: NodeCallback<GitHubApi.Issue>): void;
-    };
+          msg: GitHubApi.CreatePullRequestOpts,
+          cb: NodeCallback<GitHubApi.Issue>): void;
+    });
+    issues: ({
+      edit(msg: GitHubApi.IssuesEditOpts, cb: NodeCallback<GitHubApi.Issue>):
+          void;
+    });
     authenticate(credentials: {type: string, token: string}): void;
-    user: { get(msg: {}, cb: NodeCallback<GitHubApi.User>): void; };
+    user: ({
+      get(msg: {}, cb: NodeCallback<GitHubApi.User>): void;
+    });
   }
   namespace GitHubApi {
+    interface Options {
+      version: string;
+      protocol: string;
+    }
+    interface CreatePullRequestOpts {
+      user: string;
+      repo: string;
+      title: string;
+      head: string;
+      base: string;
+      body?: string;
+    }
+    interface IssuesEditOpts {
+      headers?: Object;
+      user: string;
+      repo: string;
+      number: number;
+      title?: string;
+      body?: string;
+      assignee?: string;
+      milestone?: number;
+      labels?: string[];
+      state?: string;
+    }
+    interface GetFromOrgOpts {
+      org: string;
+      per_page?: number;
+      page?: number;
+    }
     class Repo {
       owner: User;
       name: string;
@@ -61,7 +67,7 @@ declare module "github" {
       assignee: User;
       milestone: Milestone;
       state: string;
-      labels: { name: string, color: string, url: string }[];
+      labels: {name: string, color: string, url: string}[];
       user: User;
     }
     interface PullRequest extends Issue {}

--- a/custom_typings/hydrolysis.d.ts
+++ b/custom_typings/hydrolysis.d.ts
@@ -1,4 +1,4 @@
-declare module "hydrolysis" {
+declare module 'hydrolysis' {
   interface Options {
     filter?: (path: string) => boolean;
   }

--- a/custom_typings/nodegit.d.ts
+++ b/custom_typings/nodegit.d.ts
@@ -1,4 +1,4 @@
-declare module "nodegit" {
+declare module 'nodegit' {
   export class Signature { static now(name: string, email: string): Signature; }
   export class Cred {
     static userpassPlaintextNew(value: string, kind: string): Cred;
@@ -6,7 +6,9 @@ declare module "nodegit" {
   }
   export class Branch {
     static create(
-        repo: Repository, branchName: string, commit: Commit,
+        repo: Repository,
+        branchName: string,
+        commit: Commit,
         force: boolean): Promise<Reference>;
   }
 
@@ -23,9 +25,7 @@ declare module "nodegit" {
     credentials: CredentialsCallback;
   }
 
-  export class FetchOptions {
-    callbacks: FetchCallbacks;
-  }
+  export class FetchOptions { callbacks: FetchCallbacks; }
   class CloneOptions {
     fetchOpts: FetchOptions;
   }
@@ -36,17 +36,19 @@ declare module "nodegit" {
   export class Repository {
     static open(path: string): Promise<Repository>;
     createCommitOnHead(
-        filesToAdd: string[], author: Signature, committer: Signature,
+        filesToAdd: string[],
+        author: Signature,
+        committer: Signature,
         message: string): Promise<Oid>;
     getHeadCommit(): Promise<Commit>;
     setHead(refname: string): Promise<Number>;
     getBranchCommit(branch: string): Promise<Commit>;
-    checkoutBranch(branch: string | Reference): Promise<void>;
-    getRemote(remote: string): Promise<Remote>
-    fetchAll(fetchOpts: FetchOptions): Promise<void>
+    checkoutBranch(branch: string|Reference): Promise<void>;
+    getRemote(remote: string): Promise<Remote>;
+    fetchAll(fetchOpts: FetchOptions): Promise<void>;
     defaultSignature(): Signature;
     setHeadDetached(commitish: Oid, a: any, b: any): Number;
-    getReferenceCommit(name: string | Reference): Promise<Commit>;
+    getReferenceCommit(name: string|Reference): Promise<Commit>;
     checkoutRef(ref: Reference): Promise<void>;
     path(): string;
     workdir(): string;
@@ -64,25 +66,19 @@ declare module "nodegit" {
   }
   export class Oid {}
   export class Tree {}
-  export class Commit {
-    id(): string
-  }
-  export class Reference {
-    static list(repo: Repository): Promise<any>
-  }
+  export class Commit { id(): string }
+  export class Reference { static list(repo: Repository): Promise<any> }
 
   export class Tag {
-    static list(repo: Repository): Promise<string[]>
-    static lookup(repo: Repository, id: string|Oid|Tag): Tag
-    targetId(): Oid
+    static list(repo: Repository): Promise<string[]>;
+    static lookup(repo: Repository, id: string|Oid|Tag): Tag;
+    targetId(): Oid;
   }
 
-  type TreeIsh  = Oid | Tree | Commit | Reference
+  type TreeIsh = Oid|Tree|Commit|Reference
 
 
-  export interface CheckoutOptions {
-    checkoutStrategy: Number;
-  }
+  export interface CheckoutOptions { checkoutStrategy: Number; }
 
   interface Strategies {
     FORCE: Number;
@@ -90,7 +86,7 @@ declare module "nodegit" {
 
   export class Checkout {
     static STRATEGY: Strategies;
-    static tree(repo: Repository, treeIsh: TreeIsh): Promise<void>
+    static tree(repo: Repository, treeIsh: TreeIsh): Promise<void>;
     static head(repo: Repository, options?: CheckoutOptions): Promise<void>
   }
 }

--- a/custom_typings/pad.d.ts
+++ b/custom_typings/pad.d.ts
@@ -1,4 +1,4 @@
-declare module "pad" {
+declare module 'pad' {
   interface Options {
     strip: boolean;
   }

--- a/custom_typings/promisify-node.d.ts
+++ b/custom_typings/promisify-node.d.ts
@@ -1,4 +1,4 @@
-declare module "promisify-node" {
+declare module 'promisify-node' {
   function promisify<T>(f: (cb: NodeCallback<T>) => void): () => Promise<T>;
   function promisify<A1, T>(f: (a: A1, cb: NodeCallback<T>) => void): (a: A1) =>
       Promise<T>;

--- a/custom_typings/resolve.d.ts
+++ b/custom_typings/resolve.d.ts
@@ -1,7 +1,5 @@
-declare module "resolve" {
-  interface ResolveOpts {
-
-  }
+declare module 'resolve' {
+  interface ResolveOpts {}
 
   interface ResolveCb {
     function(err: Error, res: string): void;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@types/progress": "^1.1.8",
     "@types/rimraf": "^0.0.28",
     "@types/semver": "^5.1.0",
-    "chai": "^2.2.0",
     "clang-format": "=1.0.45",
     "tslint": "^3.10.2",
     "typescript": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "tattoo": "lib/tattoo.js"
   },
   "scripts": {
-    "format": "find src | grep '\\.ts$' | xargs clang-format --style=file -i",
-    "test": "tslint *.ts custom_typings/*.ts",
+    "format": "find src custom_typings | grep '\\.ts$' | xargs clang-format --style=file -i",
+    "test": "tslint src/*.ts src/**/*.ts custom_typings/*.ts",
     "build": "tsc",
     "tattoo": "node lib/tattoo.js",
     "build:watch": "tsc -w",
@@ -46,7 +46,9 @@
     "@types/progress": "^1.1.8",
     "@types/rimraf": "^0.0.28",
     "@types/semver": "^5.1.0",
+    "chai": "^2.2.0",
     "clang-format": "=1.0.45",
+    "tslint": "^3.10.2",
     "typescript": "^2.0.3",
     "watch": "^0.17.1"
   },


### PR DESCRIPTION
This was initially just clang-format related (I run format on the custom typings files since they're linted too).  However, I had to modify the typings file for CommandLineArgs because the types needed to be exposed in the namespace in the way I'm using them in the refactoring branch and this meant moving their definitions to make them visible, though otherwise functionally identical.
