### PR TITLE
Support checkoutRefs on wildcards so PolymerElements/paper-*#2.0-preview works.

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -235,6 +235,10 @@ export function parseGitHubRepoRefString(refString: string): GitHubRepoRef {
 /**
  * @returns whether the matcherRef matches the targetRef, which allows for the
  *     case-insensitive match as well as wildcards.
+ * TODO(usergenic): This method intentionally doesn't match the checkout refs
+ * of two repo refs.  We'll need this method to support an option to do so in
+ * order to support wildcard exclude and skip-tests options to filter out items
+ * by checkout refs.
  */
 export function matchRepoRef(
     matcherRef: GitHubRepoRef, targetRef: GitHubRepoRef): boolean {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -302,8 +302,18 @@ export class Runner {
       if (repoRef.repoName.match(/\*/)) {
         expandedRepoRefs.push.apply(
             expandedRepoRefs,
-            allGitHubRepoRefs.filter(
-                otherRepoRef => git.matchRepoRef(repoRef, otherRepoRef)));
+            allGitHubRepoRefs
+                .filter(otherRepoRef => git.matchRepoRef(repoRef, otherRepoRef))
+                .map(otherRepoRef => {
+                  // Set the checkoutRef of the matcVhed repos to the
+                  // checkoutRef
+                  // of the wildcard.
+                  return {
+                    ownerName: otherRepoRef.ownerName,
+                    repoName: otherRepoRef.repoName,
+                    checkoutRef: repoRef.checkoutRef
+                  };
+                }));
       } else {
         expandedRepoRefs.push(repoRef);
       }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -305,9 +305,8 @@ export class Runner {
             allGitHubRepoRefs
                 .filter(otherRepoRef => git.matchRepoRef(repoRef, otherRepoRef))
                 .map(otherRepoRef => {
-                  // Set the checkoutRef of the matcVhed repos to the
-                  // checkoutRef
-                  // of the wildcard.
+                  // Set the checkoutRef of the matched repos to the
+                  // checkoutRef of the wildcard.
                   return {
                     ownerName: otherRepoRef.ownerName,
                     repoName: otherRepoRef.repoName,


### PR DESCRIPTION
This is the important missing feature for testing of elements for the big Polymer 2.0 push, allowing checkout refs to be used in wildcards.  Was simple fix.