### PR TITLE
Fixing config merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ rerun.sh
 lib
 node_modules
 github-token
+tattoo_config.json
 tattoo_workspace
 *.js
 typings

--- a/src/bin/tattoo.ts
+++ b/src/bin/tattoo.ts
@@ -31,11 +31,11 @@ async function main() {
       skipTests: cliOptions['skip-test'],
       tests: cliOptions['test'],
       verbose: cliOptions['verbose'],
-      wctFlags: cliOptions['wct-flags'] || [],
+      wctFlags: cliOptions['wct-flags'],
       workspaceDir: cliOptions['workspace-dir']
     };
-    if (runnerOptions.wctFlags.length === 0) {
-      runnerOptions.wctFlags.push('--local chrome');
+    if (!runnerOptions.wctFlags) {
+      runnerOptions.wctFlags = ['--local chrome'];
     }
     const runner: Runner = new Runner(runnerOptions);
     await runner.run();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -229,7 +229,8 @@ export function mergeConfigFileOptions(
       if (typeof cfOptions[name] === 'string') {
         cfOptions[name] = [cfOptions[name]];
       }
-      options[name].push.apply(options[name], cfOptions[name]);
+      options[name] = options[name] ? options[name].concat(cfOptions[name]) :
+                                      cfOptions[name];
     }
   }
 


### PR DESCRIPTION
Presence of a wct-flags entry in tattoo_config.json was causing app to blow up because there was no CLI option value for wct-flags and merging with undefined blew things up.  Fixed. 