### PR TITLE
Fixing np discovered failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,24 +167,24 @@ tattoo (test all the things over & over)
 
 Options
 
-  -t, --test string[]          Repositories to test. (This is the default
+  -t, --test string[]          Repositories to test.  (This is the default
                                option, so the --test/-t switch itself is not
                                required.)
-  -s, --skip-test string[]     Repositories not to test. Overrides the values
+  -s, --skip-test string[]     Repositories not to test.  Overrides the values
                                from the --test
-  -r, --require string[]       Explicit repos to load. Specifying explicit
+  -r, --require string[]       Explicit repos to load.  Specifying explicit
                                repos will disable running on the default set of
                                repos for the user.
-  -e, --exclude string[]       Repositories not to load. Overrides the values
+  -e, --exclude string[]       Repositories not to load.  Overrides the values
                                from the --repo and --test flag.
   -f, --fresh                  Set to clone all repos from remote instead of
                                updating local copies.
   -c, --config-file string     Specify path to a json file which contains base
-                               configuration values. Command-line options flags
-                               supercede values in file where they differ. If
+                               configuration values.  Command-line options
+                               supercede values in file where they differ.  If
                                file is missing, Tattoo will ignore.
   -C, --color string           Set to "off" if you do not want color in your
-                               output. Defaults to "on".
+                               output.  Defaults to "on".
   -g, --github-token string    Provide github token via command-line flag
                                instead of "github-token" file.
   -v, --verbose                Set to print output from failed tests.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,8 +103,8 @@ export const cliOptionDefinitions = [
     defaultValue: [],
     multiple: true,
     description:
-        'Explicit repos to load. Specifying explicit repos will disable' +
-        ' running on the default set of repos for the user.'
+        'Explicit repos to load.  Specifying explicit repos will disable ' +
+        'running on the default set of repos for the user.'
   },
   {
     name: 'exclude',
@@ -113,8 +113,8 @@ export const cliOptionDefinitions = [
     defaultValue: [],
     multiple: true,
     description:
-        'Repositories not to load.  Overrides the values from the --repo' +
-        ' and --test flag.'
+        'Repositories not to load.  Overrides the values from the --repo ' +
+        'and --test flag.'
   },
   {
     name: 'fresh',
@@ -129,9 +129,9 @@ export const cliOptionDefinitions = [
     type: String,
     defaultValue: 'tattoo_config.json',
     description:
-        'Specify path to a json file which contains base configuration' +
-        ' values.  Command-line options flags supercede values in file ' +
-        ' where they differ.  If file is missing, Tattoo will ignore.'
+        'Specify path to a json file which contains base configuration ' +
+        'values.  Command-line options supercede values in file where ' +
+        'they differ.  If file is missing, Tattoo will ignore.'
   },
   {
     name: 'color',
@@ -168,8 +168,8 @@ export const cliOptionDefinitions = [
     alias: 'd',
     type: String,
     description:
-        'Override the default path "tattoo_workspace" where the repositories' +
-        ' will be cloned and web-component-tester will run.'
+        'Override the default path "tattoo_workspace" where the repositories ' +
+        'will be cloned and web-component-tester will run.'
   },
   {
     name: 'help',

--- a/src/git.ts
+++ b/src/git.ts
@@ -203,7 +203,7 @@ export async function checkoutOriginRef(
   return nodegitRepo.getBranch('refs/remotes/origin/' + checkoutRef)
       .then(function(reference) {
         // checkout branch
-        return nodegitRepo.checkoutRef(reference);
+        nodegitRepo.checkoutRef(reference);
       })
       .then(() => nodegitRepo);
 }


### PR DESCRIPTION
I was about to release new version of tattoo, but then np went and found some broken-ness that regular local `npm test` runs did not find.  This was due to clearing node_modules prior to test I suppose.